### PR TITLE
Update tydomMessagehandler to add door opening sensors

### DIFF
--- a/tydomMessagehandler.py
+++ b/tydomMessagehandler.py
@@ -21,7 +21,7 @@ deviceAlarmDetailsKeywords = ['alarmSOS','zone1State','zone2State','zone3State',
 deviceLightKeywords = ['level','onFavPos','thermicDefect','battDefect','loadDefect','cmdDefect','onPresenceDetected','onDusk']
 deviceLightDetailsKeywords = ['onFavPos','thermicDefect','battDefect','loadDefect','cmdDefect','onPresenceDetected','onDusk']
 
-deviceDoorKeywords = ['openState']
+deviceDoorKeywords = ['openState', 'intrusionDetect']
 deviceDoorDetailsKeywords = ['onFavPos','thermicDefect','obstacleDefect','intrusion','battDefect']
 
 deviceCoverKeywords = ['position','onFavPos','thermicDefect','obstacleDefect','intrusion','battDefect']


### PR DESCRIPTION
Opening sensors contain no openState attribute but an intrusionDetect attribute.

Here is the format of my sensors' config:
```
{
  "id_endpoint": 1591129980,
  "first_usage": "klineDetect",
  "id_device": 1591129980,
  "name": "Porte Service",
  "anticipation_start": false,
  "picto": "picto_detect_door_service",
  "last_usage": "klineDoor"
}
```

And the associated data:
```
{
  "id": XXXXXXXXXX,
  "endpoints": [
    {
      "id": XXXXXXXXXX,
      "error": 0,
      "data": [
        {
          "name": "config",
          "validity": "upToDate",
          "value": 2
        },
        {
          "name": "battDefect",
          "validity": "upToDate",
          "value": false
        },
        {
          "name": "supervisionMode",
          "validity": "upToDate",
          "value": "LONG"
        },
        {
          "name": "intrusionDetect",
          "validity": "upToDate",
          "value": false
        }
      ]
    }
  ]
}
```